### PR TITLE
added kubernetes

### DIFF
--- a/kubernetes-Dockerfile
+++ b/kubernetes-Dockerfile
@@ -1,0 +1,20 @@
+# Use Node.js base image
+FROM node:18-alpine
+
+# Create app directory
+WORKDIR /app
+
+# Copy package files
+COPY package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Install ts-node globally
+RUN npm install -g ts-node
+
+# Copy source code
+COPY . .
+
+# Run the script once and exit
+CMD ["npx", "tsx", "index.ts"]

--- a/kubernetes-cronjob.yaml
+++ b/kubernetes-cronjob.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ddns-config
+data:
+  domain-name: example.com
+  record-names: subdomain1,subdomain2
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloudflare-credentials
+type: Opaque
+data:
+  # These values need to be base64 encoded. Here is a command to convert to base64:
+  #echo "something" | base64
+  email: bXlAZW1haWwuY29tCg== #my@email.com
+  api-key: YWJjMTIzCg== #abc123
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cloudflare-ddns-update
+spec:
+  schedule: "0 * * * *"  # Run every hour
+  concurrencyPolicy: Replace
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: ddns-updater
+            image: mrorbitman/cloudflare-ddns-helper:latest #change this to the image you compiled using the kubernetes Dockerfile
+            imagePullPolicy: Always
+            env:
+            - name: CLOUDFLARE_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: cloudflare-credentials
+                  key: email
+            - name: CLOUDFLARE_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: cloudflare-credentials
+                  key: api-key
+            - name: DOMAIN_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: ddns-config
+                  key: domain-name
+            - name: RECORD_NAMES
+              valueFrom:
+                configMapKeyRef:
+                  name: ddns-config
+                  key: record-names
+          restartPolicy: Never


### PR DESCRIPTION
basically, Dockerfile was changed to just running the script when spun up. so that the kubernetes cronjob can simply run this container once an hour and it will run the script and then exit and done.